### PR TITLE
fix windows getCurrentBrowserUrl bug

### DIFF
--- a/app/scripts/comp/launcher/launcher-utools.js
+++ b/app/scripts/comp/launcher/launcher-utools.js
@@ -234,6 +234,28 @@ if (window.launcherOpenedFile) {
 window.utools.onPluginReady(() => {
     Events.emit('app-ready');
 });
+window.utools.onPluginEnter(({ code, type, payload, optional }) => {
+    if (type === 'text') {
+        window.utools.setSubInput((val) => {
+            if (val) {
+                document.querySelector('.list__search-field').value = val.text;
+                Events.emit('add-filter', { text: val.text });
+            }
+        }, 'search');
+        let url = window.utools.getCurrentBrowserUrl();
+        // 处理windows获取BrowserUrl没有http前缀
+        if (url && !/^http/.test(url)) {
+            url = `http://${url}`;
+        }
+        if (url) {
+            const host = new URL(url)?.hostname?.split('.').slice(-2).join('.');
+            if (host) {
+                window.utools.setSubInputValue(host);
+                window.utools.subInputSelect();
+            }
+        }
+    }
+});
 Events.on('app-ready', () =>
     setTimeout(() => {
         Launcher.checkOpenFiles();

--- a/app/scripts/views/list-search-view.js
+++ b/app/scripts/views/list-search-view.js
@@ -164,29 +164,10 @@ class ListSearchView extends View {
         const keypressHandler = (e) => this.documentKeyPress(e);
         Events.on('keypress', keypressHandler);
         this.removeKeypressHandler = () => Events.off('keypress', keypressHandler);
-        if (window.utools) {
-            window.utools.onPluginEnter(({ code, type, payload, optional }) => {
-                if (type === 'text') {
-                    window.utools.setSubInput((val) => {
-                        this.inputEl.val(val.text);
-                        Events.emit('add-filter', { text: val.text });
-                    }, 'search');
-                    const url = window.utools.getCurrentBrowserUrl();
-                    if (url) {
-                        const host = new URL(url)?.hostname?.split('.').slice(-2).join('.');
-                        if (host) {
-                            window.utools.setSubInputValue(host);
-                            window.utools.subInputSelect();
-                        }
-                    }
-                }
-            });
-        }
     }
 
     viewHidden() {
         this.removeKeypressHandler();
-        window.utools?.removeSubInput();
     }
 
     render() {


### PR DESCRIPTION
获取不到host目测是windows中utools.getCurrentBrowserUrl()没有protocol导致
从list-search-view.js移除window.utools.onPluginEnter是因为在开发模式下会卡死超过5秒，在生产模式不确定会不会
